### PR TITLE
fix: remove dead birkConstant branch in getMaterialPropertyFromString

### DIFF
--- a/gemc/gsystem/gmaterial.cc
+++ b/gemc/gsystem/gmaterial.cc
@@ -136,8 +136,6 @@ void GMaterial::getMaterialPropertyFromString(const std::string &parameter, cons
 			slowtimeconstant = gutilities::getG4Number(trimmedComponent);
 		} else if (propertyName == "yieldratio") {
 			yieldratio = gutilities::getG4Number(trimmedComponent);
-		} else if (propertyName == "birkConstant") {
-			birksConstant = gutilities::getG4Number(trimmedComponent);
 		} else if (propertyName == "rayleigh") {
 			rayleigh.push_back(gutilities::getG4Number(trimmedComponent));
 		}


### PR DESCRIPTION
Remove unreachable branch that tested for "birkConstant" (typo, missing 's').

The canonical key is "birksConstant" but Birks constant is loaded via
assign_if_set, not name-dispatch — so this branch was dead code.

The fix follows the issue author's preferred solution (removal rather than typo correction).

Fixes #138