### PR TITLE
Fix sphere vertex sampling: compare squared radius to squared bound

### DIFF
--- a/gemc/gparticle/gparticle.cc
+++ b/gemc/gparticle/gparticle.cc
@@ -166,7 +166,7 @@ G4ThreeVector Gparticle::calculateVertex() {
 				z      = randomizeNumberFromSigmaWithModel(0, max_radius, gutilities::uniform);
 				radius = x * x + y * y + z * z;
 			}
-			while (radius > max_radius);
+			while (radius > max_radius * max_radius);
 
 			// Offset the sampled point by the nominal vertex.
 			x = x + v.x();


### PR DESCRIPTION
In-sphere rejection sampling compared the squared magnitude `x*x+y*y+z*z` against the un-squared `max_radius`, so the accepted region had radius `sqrt(max_radius)` instead of `max_radius` (e.g. `max_radius=4` accepted only radius 2). This squares the bound. The sampling cube already spans `[-max_radius, max_radius]` per component, so rejection sampling stays valid.

**Validation:** translation unit recompiled cleanly with Geant4 11.4.1 / ROOT 6.38 / Qt 6.9 (ghcr.io/gemc/src:dev-almalinux-10).

Fixes #109