### PR TITLE
Null-check physics list before dereferencing it

### DIFF
--- a/gemc/gphysics/gphysics.cc
+++ b/gemc/gphysics/gphysics.cc
@@ -56,11 +56,11 @@ GPhysics::GPhysics(const std::shared_ptr<GOptions>& gopts) :
 
 	physList = factory.GetReferencePhysList(g4physList);
 
+	if (!physList) { log->error(ERR_PHYSLISTERROR, "physics list <" + gphysList + "> could not be loaded."); }
+
 	// Register step limiters (module default add-on).
 	// This is intentionally registered even when users select a standard reference list.
 	physList->RegisterPhysics(new G4StepLimiterPhysics());
-
-	if (!physList) { log->error(ERR_PHYSLISTERROR, "physics list <" + gphysList + "> could not be loaded."); }
 
 	log->info(2, "G4PhysListFactory: <" + g4physList + "> loaded.");
 }


### PR DESCRIPTION
`g4alt::G4PhysListFactory::GetReferencePhysList()` returns `nullptr` for an unrecognized list name, but `RegisterPhysics()` was called before the `if (!physList)` guard — a typo'd physics-list name segfaulted instead of emitting `ERR_PHYSLISTERROR`. The null check now runs before the dereference. `log->error` is `[[noreturn]]`, so the null path terminates cleanly before `RegisterPhysics` (also avoiding the leaked `G4StepLimiterPhysics`).

**Validation:** translation unit recompiled cleanly with Geant4 11.4.1 / ROOT 6.38 / Qt 6.9 (ghcr.io/gemc/src:dev-almalinux-10).

Fixes #130