### PR TITLE
Guard parseFileAndRemoveComments against a comment before the first newline

### DIFF
--- a/gemc/guts/gutilities.cc
+++ b/gemc/guts/gutilities.cc
@@ -389,7 +389,11 @@ string parseFileAndRemoveComments(const string& filename, const string& commentC
 	while ((nFPos = parsedString.find(commentChars)) != string::npos) {
 		size_t firstNL  = parsedString.rfind('\n', nFPos);
 		size_t secondNL = parsedString.find('\n', nFPos);
-		parsedString.erase(firstNL, secondNL - firstNL);
+		size_t eraseStart = (firstNL == string::npos) ? 0 : firstNL;
+		size_t eraseLen   = (secondNL == string::npos)
+		                      ? string::npos
+		                      : secondNL - eraseStart;
+		parsedString.erase(eraseStart, eraseLen);
 	}
 
 	return parsedString;


### PR DESCRIPTION
`parseFileAndRemoveComments` computes the newlines around a comment marker and erases between them. `rfind('\n')` returns `npos` when the comment is on the first line, and `erase(npos, ...)` throws `std::out_of_range`. This treats `firstNL==npos` as "erase from position 0" and `secondNL==npos` (comment on the last line, no trailing newline) as "erase to end". Behavior for the common middle-of-file case is unchanged.

**Validation:** translation unit recompiled cleanly with Geant4 11.4.1 / ROOT 6.38 / Qt 6.9 (ghcr.io/gemc/src:dev-almalinux-10).

Fixes #133