### PR TITLE
JSON streamer: emit valid, correctly-nested event objects

### DIFF
--- a/gemc/gstreamer/factories/JSON/event/event.cc
+++ b/gemc/gstreamer/factories/JSON/event/event.cc
@@ -29,6 +29,7 @@ bool GstreamerJsonFactory::startEventImpl(const std::shared_ptr<GEventDataCollec
 	current_event_has_header       = false;
 	current_event_has_any_detector = false;
 	current_event_has_generated    = false;
+	current_event_digitized_entries.clear();
 
 	// Cache the event number early so it is available to the root event object.
 	event_number = event_data->getHeader()->getG4LocalEvn();
@@ -47,24 +48,37 @@ bool GstreamerJsonFactory::endEventImpl(const std::shared_ptr<GEventDataCollecti
 		return false;
 	}
 
-	// If the caller skipped the header step, emit a minimal fallback so the JSON remains valid.
+	// If the caller skipped the header step, emit a minimal fallback and close the header
+	// object (startEventImpl opened it; publishEventHeaderImpl normally writes its fields
+	// and closes it).
 	if (!current_event_has_header) {
-		current_event << "\"timestamp\": \"\", \"thread_id\": -1";
+		current_event << "\"timestamp\": \"\", \"thread_id\": -1}";
 	}
 
-	// Detector publishers leave the "detectors" object open so digitized data
-	// can be appended after true-information banks without rewriting strings.
-	if (current_event_has_any_detector) {
+	// Ensure a "detectors" object exists so the schema stays predictable and any buffered
+	// digitized data has a place to live, even when no true-information banks were published.
+	bool detectors_has_content = current_event_has_any_detector;
+	if (!current_event_has_any_detector) {
+		current_event << ", \"detectors\": {";
+		current_event_has_any_detector = true;
+	}
+
+	// Emit all buffered digitized detector arrays as a single, well-formed
+	// "digitized_by_detector" object nested inside "detectors".
+	if (!current_event_digitized_entries.empty()) {
+		if (detectors_has_content) { current_event << ", "; }
+		current_event << "\"digitized_by_detector\": {";
+		bool first = true;
+		for (const auto& entry : current_event_digitized_entries) {
+			if (!first) { current_event << ", "; }
+			first = false;
+			current_event << entry;
+		}
 		current_event << "}";
 	}
-	current_event << "}";
 
-	// Keep the event schema predictable even when no detector banks were published.
-	if (!current_event_has_any_detector) {
-		current_event << ", \"detectors\": {}";
-	}
-
-	current_event << "}";
+	current_event << "}"; // close "detectors"
+	current_event << "}"; // close the event object
 
 	writeTopLevelEntry(current_event.str());
 

--- a/gemc/gstreamer/factories/JSON/event/eventHeader.cc
+++ b/gemc/gstreamer/factories/JSON/event/eventHeader.cc
@@ -26,6 +26,7 @@ bool GstreamerJsonFactory::publishEventHeaderImpl(const std::unique_ptr<GEventHe
 	current_event << "\"timestamp\": \"" << jsonEscape(timestamp) << "\""
 				  << ", \"thread_id\": " << thread_id
 				  << ", \"g4local_event\": " << gevent_header->getG4LocalEvn();
+	current_event << "}"; // close the "header" object opened in startEventImpl
 
 	current_event_has_header = true;
 	return true;

--- a/gemc/gstreamer/factories/JSON/event/publishDigitized.cc
+++ b/gemc/gstreamer/factories/JSON/event/publishDigitized.cc
@@ -17,80 +17,54 @@ bool GstreamerJsonFactory::publishEventDigitizedDataImpl(const std::string&     
 		return false;
 	}
 
-	// The current design appends digitized content into a reserved object nested under
-	// "detectors". This avoids rewriting previously emitted detector JSON.
+	// Build this detector's digitized array into a standalone entry and buffer it.
+	// endEventImpl emits all buffered entries together as the "digitized_by_detector"
+	// object, which keeps the JSON valid regardless of how true-info and digitized
+	// publish calls interleave across detectors.
 	if (digitizedData.empty()) return true;
 
-	static const char* marker    = "\"digitized_by_detector\": {";
-	const std::string  assembled = current_event.str();
-
-	const bool has_digitized_container = (assembled.find(marker) != std::string::npos);
-
-	if (!has_digitized_container) {
-		// Ensure the event already has a detectors object before reserving a nested map
-		// for digitized collections keyed by detector name.
-		if (!current_event_has_any_detector) {
-			current_event << ", \"detectors\": {";
-			current_event_has_any_detector = true;
-		}
-		else {
-			current_event << ", ";
-		}
-
-		current_event << "\"digitized_by_detector\": {";
-	}
-
-	// If the reserved object already contains one detector entry, append a comma
-	// before adding the next one.
-	const std::string updated = current_event.str();
-	if (!updated.empty()) {
-		char last = updated.back();
-		if (last != '{') current_event << ", ";
-	}
-
-	current_event << "\"" << jsonEscape(detectorName) << "\": [";
+	std::ostringstream entry;
+	entry << "\"" << jsonEscape(detectorName) << "\": [";
 
 	bool wrote_first_hit = false;
 	for (const auto* hit : digitizedData) {
 		if (!hit) continue;
 
-		if (wrote_first_hit) current_event << ", ";
+		if (wrote_first_hit) entry << ", ";
 		wrote_first_hit = true;
 
-		current_event << "{";
+		entry << "{";
 
 		auto addr = getIdentityString(hit->getIdentity());
 
-		current_event << "\"address\": \"" << jsonEscape(addr) << "\"";
+		entry << "\"address\": \"" << jsonEscape(addr) << "\"";
 
-		current_event << ", \"vars\": {";
+		entry << ", \"vars\": {";
 
 		bool wrote_first_var = false;
 
 		// Integer observables:
 		// the argument 0 means "do not include SRO variables".
 		for (const auto& [name, value] : hit->getIntObservablesMap(0)) {
-			if (wrote_first_var) current_event << ", ";
+			if (wrote_first_var) entry << ", ";
 			wrote_first_var = true;
-			current_event << "\"" << jsonEscape(name) << "\": " << value;
+			entry << "\"" << jsonEscape(name) << "\": " << value;
 		}
 
 		// Floating-point observables.
 		for (const auto& [name, value] : hit->getDblObservablesMap(0)) {
-			if (wrote_first_var) current_event << ", ";
+			if (wrote_first_var) entry << ", ";
 			wrote_first_var = true;
-			current_event << "\"" << jsonEscape(name) << "\": " << value;
+			entry << "\"" << jsonEscape(name) << "\": " << value;
 		}
 
-		current_event << "}";
-		current_event << "}";
+		entry << "}";
+		entry << "}";
 	}
 
-	current_event << "]";
+	entry << "]";
 
-	// Close the temporary digitized_by_detector object immediately so the enclosing
-	// event remains structurally valid after this call.
-	current_event << "}";
+	current_event_digitized_entries.push_back(entry.str());
 
 	return true;
 }

--- a/gemc/gstreamer/factories/JSON/gstreamerJSONFactory.h
+++ b/gemc/gstreamer/factories/JSON/gstreamerJSONFactory.h
@@ -185,6 +185,11 @@ private:
 	/// \brief Tracks whether the current event already contains generated-particle banks.
 	bool current_event_has_generated = false;
 
+	/// \brief Buffered digitized detector arrays for the current event. endEventImpl emits
+	/// them together as the "digitized_by_detector" object, which keeps the JSON valid
+	/// regardless of how true-info and digitized publish calls interleave across detectors.
+	std::vector<std::string> current_event_digitized_entries;
+
 	/// \brief Tracks whether the plugin is currently assembling a frame object.
 	bool is_building_frame = false;
 


### PR DESCRIPTION
Reworks the JSON event serialization so events are valid, correctly-nested JSON. Two coupled defects, fixed together because both live in the shared brace-accounting of `endEventImpl`:

**#116 — header never closed.** `startEventImpl` opens `"header": {` but nothing closed it, so `generated` and `detectors` were emitted *inside* `header` instead of as siblings. (Single-detector output still parsed, but with the wrong shape.) Fixed by closing the header right after its fields are written (and in the `endEventImpl` fallback when the header step is skipped), and dropping the now-redundant header-closing brace from `endEventImpl`.

**#115 — multi-detector digitized produced invalid JSON.** Digitized data was written inline and `"digitized_by_detector"` was closed on *every* per-detector call. The base class interleaves `publishEventTrueInfoData`/`publishEventDigitizedData` **per detector** (`gstreamer.cc:93-111`), so a second digitized detector extended an already-closed object — extra braces, misplaced keys. (Note: the per-issue proposed fix of "open once, close in endEvent" does not hold under this interleaving — a later detector's true-info would land inside the still-open digitized object.) Fixed by buffering each detector's digitized array and emitting them together as one well-formed `"digitized_by_detector"` object in `endEventImpl`.

The existing schema is preserved: per-detector `"digitized": []` placeholder plus the `"digitized_by_detector"` map.

**Validation:** ran the gstreamer JSON example extended to two detectors (ctof + ftof) in the Geant4 11.4.1 / Qt6 dev container. Before: `json.tool` rejects the output (`Expecting ',' delimiter`). After: all worker files parse as valid JSON, with `header`/`generated`/`detectors` as siblings and both detectors' 10 digitized hits present under `digitized_by_detector`.

Note: filed as one PR because #115 and #116 both rewrite the same `endEventImpl` brace logic and cannot be cleanly separated.

Fixes #115
Fixes #116