### PR TITLE
Default-initialize CSV factory's cached event/run/thread ids

### DIFF
--- a/gemc/gstreamer/factories/CSV/gstreamerCSVFactory.h
+++ b/gemc/gstreamer/factories/CSV/gstreamerCSVFactory.h
@@ -262,11 +262,11 @@ private:
 	std::string timestamp;
 
 	/// \brief Cached event number copied at the start of the most recent event publish cycle.
-	int event_number;
+	int event_number = -1;
 
 	/// \brief Cached run number copied at the start of the most recent run publish cycle.
-	int runId;
+	int runId = -1;
 
 	/// \brief Cached thread id copied from the most recent event header.
-	int thread_id;
+	int thread_id = -1;
 };


### PR DESCRIPTION
`event_number`, `runId`, and `thread_id` in `GstreamerCsvFactory` were declared without initializers. In run mode, `publishRunDigitizedDataImpl` writes `event_number` and `thread_id` directly, but the run path never goes through `startEvent`/`publishEventHeader`, so both ints were read while uninitialized — undefined behavior, emitting garbage into the `evn` and `thread_id` columns of every run-mode CSV row.

Initialize all three to `-1` (matching the JSON factory's fallback convention) so the run-mode columns are deterministic and machine-parseable.

**Validation:** CSV plugin compiles clean (Geant4 11.4.1 dev container).

Fixes #128