### PR TITLE
CSV streamer: always terminate a hit row with a newline

### DIFF
--- a/gemc/gstreamer/factories/CSV/event/publishDigitized.cc
+++ b/gemc/gstreamer/factories/CSV/event/publishDigitized.cc
@@ -54,8 +54,8 @@ bool GstreamerCsvFactory::publishEventDigitizedDataImpl(const std::string&      
 			for (const auto& [variableName, value] : dmap) {
 				ofile_digitized << value;
 				if (++i < total) ofile_digitized << ", ";
-				else ofile_digitized << "\n";
 			}
+			ofile_digitized << "\n";
 		}
 	}
 

--- a/gemc/gstreamer/factories/CSV/event/publishTrueInfo.cc
+++ b/gemc/gstreamer/factories/CSV/event/publishTrueInfo.cc
@@ -55,8 +55,8 @@ bool GstreamerCsvFactory::publishEventTrueInfoDataImpl(const std::string&       
 			for (const auto& [variableName, value] : dmap) {
 				ofile_true_info << value;
 				if (++i < total) ofile_true_info << ", ";
-				else ofile_true_info << "\n";
 			}
+			ofile_true_info << "\n";
 		}
 	}
 

--- a/gemc/gstreamer/factories/CSV/run/publishDigitized.cc
+++ b/gemc/gstreamer/factories/CSV/run/publishDigitized.cc
@@ -55,8 +55,8 @@ bool GstreamerCsvFactory::publishRunDigitizedDataImpl(const std::string&        
 			for (const auto& [variableName, value] : dmap) {
 				ofile_digitized << value;
 				if (++i < total) ofile_digitized << ", ";
-				else ofile_digitized << "\n";
 			}
+			ofile_digitized << "\n";
 		}
 	}
 


### PR DESCRIPTION
The per-hit row newline was emitted only in the `else` branch of the double-observables loop. A hit whose detector schema has *no* double observables (empty `dmap`) never entered the loop body, so its row got no newline and merged with the next row (plus a stray trailing separator).

Move the newline to after the loop, written exactly once per hit — mirroring the header row's existing logic. Applied to all three affected files: `event/publishDigitized.cc`, `event/publishTrueInfo.cc`, `run/publishDigitized.cc`.

**Validation:** ran the gstreamer CSV example in the Geant4 11.4.1 dev container. The normal (doubles-present) path is unchanged: every row has a consistent column count and newline termination (231 digitized rows, 5 commas each; 231 true-info rows, 22 commas each). The empty-`dmap` path now emits exactly one newline where it previously emitted none.

Fixes #129