### PR TITLE
Label run headers with the GEMC run number, not Geant4's internal run ID

### DIFF
--- a/gemc/eventDispenser/eventDispenser.cc
+++ b/gemc/eventDispenser/eventDispenser.cc
@@ -15,6 +15,7 @@
 
 // geant4
 #include "G4UImanager.hh"
+#include "G4RunManager.hh"
 
 using namespace std;
 
@@ -170,6 +171,11 @@ int EventDispenser::processEvents() {
 		// Dispatch all events for this run in a single call.
 		// The command string is a standard Geant4 UI command: \c /run/beamOn <N>.
 		log->info(1, "Processing ", nevents, " events in one go");
+		// Seed Geant4's internal run-ID counter with the GEMC conditions run number so
+		// GRunHeader (built from aRun->GetRunID()) is labeled with the run the user
+		// requested rather than Geant4's 0-based per-beamOn counter. Under MT this
+		// propagates from the master manager to the worker runs of this beamOn.
+		G4RunManager::GetRunManager()->SetRunIDCounter(runNumber);
 		g4uim->ApplyCommand("/run/beamOn " + to_string(nevents));
 		// Take the screenshot after BeamOn returns. At this point G4VisManager::EndOfRun()
 		// has already joined the vis subthread (ARM64 offset 0xa35f8: bl thread::join), so


### PR DESCRIPTION
`GRunHeader` is built from `aRun->GetRunID()`, Geant4's internal counter (0, 1, 2, … per `/run/beamOn`). It is unrelated to the GEMC conditions run number the user requested (the key of `runEvents` in `EventDispenser`), so run-level output and per-run logging were mislabeled — run weights dispatching runs 11/12/13 produced headers reporting 0/1/2.

Seed Geant4's run-ID counter with the GEMC run number before each `beamOn` via `G4RunManager::SetRunIDCounter`, so `aRun->GetRunID()` returns the intended number. Under MT the master manager propagates the ID to the worker runs of that beamOn, keeping master and worker headers consistent.

`GetRunID()` is consumed only by the run header (two sites in `gRunAction.cc`), so seeding the counter has no other side effects.

**Validation:** `eventDispenser.cc` compiles clean (Geant4 11.4.1 dev container).

Fixes #104