### PR TITLE
Normalize run data once, not once per run streamer

### DIFF
--- a/gemc/actions/run/gRunAction.cc
+++ b/gemc/actions/run/gRunAction.cc
@@ -256,14 +256,16 @@ void GRunAction::publish_run_data(const std::shared_ptr<GRunDataCollection> &run
 		           " no run streamer map available - run data will not be published.");
 	}
 
+	// Normalize once, before publishing: normalize_run_data() mutates run_data_collaction
+	// in place and is NOT idempotent, so running it per streamer would divide the run
+	// observables by events_processed once for every configured run streamer.
+	normalize_run_data(run_data_collaction);
+
 	for (const auto &[name, gstreamer]: *gstreamer_run_map) {
 		if (gstreamer == nullptr) {
 			log->error(ERR_STREAMERMAP_NOT_EXISTING, FUNCTION_NAME,
 			           " null gstreamer instance for run streamer ", name);
 		}
-
-
-		normalize_run_data(run_data_collaction);
 
 		gstreamer->publishRunData(run_data_collaction);
 	}


### PR DESCRIPTION
`publish_run_data` called `normalize_run_data` inside the per-streamer loop. `normalize_run_data` mutates the shared `run_data_collaction` in place (replacing each normalized observable with `value/events_processed`) and is **not idempotent**, so with two or more run-mode streamers the second streamer published `value/N²`, the third `value/N³`, and so on.

Hoist the normalization out of the loop so it runs exactly once per run regardless of streamer count.

**Validation:** `gRunAction.cc` compiles clean (Geant4 11.4.1 dev container).

Fixes #105