### PR TITLE
Key the streamer map by output name so same-format outputs don't collide

### DIFF
--- a/gemc/gstreamer/gstreamer.h
+++ b/gemc/gstreamer/gstreamer.h
@@ -616,13 +616,23 @@ namespace gstreamer {
 		for (const auto& gstreamer_def : gstreamer::getGStreamerDefinition(gopts)) {
 			auto        gstreamer_def_thread = GStreamerDefinition(gstreamer_def, thread_id);
 			std::string gstreamer_plugin     = gstreamer_def_thread.gstreamerPluginName();
+			// Key the map by the unique per-output rootname so that multiple same-format
+			// outputs (e.g. two csv files) do not collide; the plugin library is still
+			// loaded by the format-derived plugin name.
+			const std::string& output_key   = gstreamer_def_thread.rootname;
 
-			// Load the plugin object for this configured output.
+			// Load the plugin object for this configured output. Each call returns a
+			// fresh GStreamer instance, so same-format outputs stay independent.
 			auto streamer = manager.LoadAndRegisterObjectFromLibrary<GStreamer>(gstreamer_plugin, gopts);
-			gstreamers->emplace(gstreamer_plugin, streamer);
+			auto [it, inserted] = gstreamers->emplace(output_key, streamer);
+			if (!inserted) {
+				log->warning("duplicate gstreamer output name '", output_key,
+				             "' - ignoring later definition");
+				continue;
+			}
 
-			// Bind the thread-specialized definition to the plugin instance.
-			gstreamers->at(gstreamer_plugin)->define_gstreamer(gstreamer_def_thread);
+			// Bind the thread-specialized definition to this (freshly created) plugin instance.
+			it->second->define_gstreamer(gstreamer_def_thread);
 		}
 
 		return gstreamers;


### PR DESCRIPTION
`gstreamersMapPtr` keyed the per-thread streamer map by the format-derived plugin name (`"gstreamer_<format>_plugin"`), so two outputs of the same format (e.g. two `csv` files with different filenames) mapped to the same key: the second `emplace` was a no-op and the following `.at()->define_gstreamer()` rebound the *first* instance to the *second* definition — silently dropping one output.

Key the map by the unique per-output `rootname` instead. The plugin library is still loaded by the format-derived name, and each `LoadAndRegisterObjectFromLibrary` call returns a fresh `GStreamer` instance (only the dlopen handle is cached), so same-format outputs stay independent. Duplicate output names are skipped with a warning. The map key is only used as a log label at all iteration sites, so the rename is safe.

**Validation:** ran the gstreamer CSV example with two `csv` outputs in the Geant4 11.4.1 dev container. Before: only the second output's 16 files were written (the first was lost). After: both output file sets (16 + 16) are produced.

Fixes #106