### PR TITLE
Only stash worker run data when a run streamer will drain it

### DIFF
--- a/gemc/actions/run/gRunAction.cc
+++ b/gemc/actions/run/gRunAction.cc
@@ -166,7 +166,9 @@ void GRunAction::EndOfRunAction(const G4Run *aRun) {
 	// Worker threads do not publish merged run data. Instead, they hand their
 	// completed run-level accumulation to the shared pool and return.
 	if (!IsMaster()) {
-		stash_worker_run_data();
+		// Only contribute to the master merge pool when a run-mode streamer will drain it;
+		// otherwise the pool is never taken and would accumulate stale prior-run data.
+		if (need_a_run_streamer) { stash_worker_run_data(); }
 		return;
 	}
 


### PR DESCRIPTION
Workers called `stash_worker_run_data()` at the end of every run, but the master drains the static pool (`take_completed_worker_run_data`) only when `need_a_run_streamer` is true. With no run-mode digitizer, the pool was never cleared and grew run after run; a later run that *did* enable a run streamer then merged in all the stale prior-run contributions — double-counting `events_processed` (the normalization denominator) and run-summary counters — and leaked memory in the common no-run-streamer case.

Gate the worker stash on `need_a_run_streamer`, the same condition the master uses to drain. Workers and master compute it identically in `BeginOfRunAction`, so the pool is filled iff it will be drained that run.

**Validation:** `gRunAction.cc` compiles clean (Geant4 11.4.1 dev container).

Fixes #126