### PR TITLE
Parse multipole field parameters through getG4Number to honor units

### DIFF
--- a/gemc/gfields/gfield.h
+++ b/gemc/gfields/gfield.h
@@ -7,6 +7,7 @@
 // gemc
 #include <gemc/gfactory/gfactory.h>
 #include <gemc/gbase/gbase.h>
+#include <gemc/guts/gutilities.h>
 
 
 constexpr const char* GFIELD_LOGGER   = "gfield";
@@ -148,7 +149,7 @@ public:
 	 * \param key Map key to retrieve.
 	 * \return Parsed floating-point value.
 	 */
-	double get_field_parameter_double(const std::string& key) { return stod(gfield_definitions.field_parameters[key]); }
+	double get_field_parameter_double(const std::string& key) { return gutilities::getG4Number(gfield_definitions.field_parameters[key]); }
 
 	/**
 	 * \brief Hook for configuring module loggers from options.


### PR DESCRIPTION
`get_field_parameter_double` used bare `std::stod`, which silently truncates unit expressions: `stod("30*deg")` returns `30.0` and drops `*deg`. So multipole/dipole parameters written the documented way (`vx/vy/vz` as `"10*cm"`, `rotation_angle` as `"30*deg"`, `strength` as `"2*tesla"`) were interpreted in raw internal units, producing fields with the wrong magnitude, position, and rotation — silently, with no error.

Route the double accessor through `gutilities::getG4Number`, which parses unit expressions (`minimum_step` in `gfield_options.cc` already uses it). `get_field_parameter_int` stays on `stoi`: its only consumer is `pole_number`, a unitless count.

**Validation:** the multipole field plugin (`gfield_multipoles.cc`, the consumer) compiles clean against the new accessor (Geant4 11.4.1 dev container).

Fixes #107