### PR TITLE
Stop mutating dirLocation while importing CAD files

### DIFF
--- a/gemc/gsystem/gsystemFactories/cad/loadGeometry.cc
+++ b/gemc/gsystem/gsystemFactories/cad/loadGeometry.cc
@@ -26,7 +26,7 @@ void GSystemCADFactory::loadGeometry(GSystem* s) {
 
 		// Import each STL as a volume. Each volume name is derived from the filename.
 		for (const auto& cf : cadFiles) {
-			s->addVolumeFromFile(GSYSTEMCADTFACTORYLABEL, dirLocation.append("/").append(cf));
+			s->addVolumeFromFile(GSYSTEMCADTFACTORYLABEL, dirLocation + "/" + cf);
 		}
 
 		// If the file cad__<variation>.yaml is found in dirLocation, modify the gvolumes accordingly.


### PR DESCRIPTION
The STL import loop used `dirLocation.append("/").append(cf)`, which **mutates** `dirLocation` in place. After the first file, `dirLocation` was no longer the directory path — the second iteration produced paths like `.../dir/a.stl/b.stl`, so only the first STL resolved. The mangled value also leaked to the next line, where the per-variation `cad__<variation>.yaml` modifier path is built, so that override file was never found.

Use non-mutating concatenation (`dirLocation + "/" + cf`) so `dirLocation` stays the directory path for every file and for the YAML lookup.

**Validation:** compiles clean (Geant4 11.4.1 dev container).

Fixes #110