### PR TITLE
Return the ASCII system stream as unique_ptr to stop a per-load leak

### DIFF
--- a/gemc/gsystem/gsystemFactories/text/loadGeometry.cc
+++ b/gemc/gsystem/gsystemFactories/text/loadGeometry.cc
@@ -34,7 +34,6 @@ void GSystemTextFactory::loadGeometry(GSystem* system) {
 				gutilities::getStringVectorFromStringWithDelimiter(dbline, "|");
 			system->addGVolume(gvolumePars);
 		}
-
-		IN->close();
+		// IN (unique_ptr<ifstream>) closes the file and frees the stream on scope exit.
 	}
 }

--- a/gemc/gsystem/gsystemFactories/text/loadMaterials.cc
+++ b/gemc/gsystem/gsystemFactories/text/loadMaterials.cc
@@ -28,7 +28,6 @@ void GSystemTextFactory::loadMaterials(GSystem* system) {
 				gutilities::getStringVectorFromStringWithDelimiter(dbline, "|");
 			system->addGMaterial(gmaterialsPars);
 		}
-
-		IN->close();
+		// IN (unique_ptr<ifstream>) closes the file and frees the stream on scope exit.
 	}
 }

--- a/gemc/gsystem/gsystemFactories/text/systemTextFactory.cc
+++ b/gemc/gsystem/gsystemFactories/text/systemTextFactory.cc
@@ -14,12 +14,13 @@
 
 // cpp
 #include <fstream>
+#include <memory>
 
 // returns the file stream, checking all possible directories.
 // SYSTEMTYPE can be:
 // - GTEXTGEOMTYPE (mandatory, exit if not found)
 // - GTEXTMATSTYPE
-std::ifstream* GSystemTextFactory::gSystemTextFileStream(GSystem* system, const std::string& SYSTEMTYPE) {
+std::unique_ptr<std::ifstream> GSystemTextFactory::gSystemTextFileStream(GSystem* system, const std::string& SYSTEMTYPE) {
 	std::string fileName  = system->getFilePath();
 	std::string variation = system->getVariation();
 	std::string fname     = fileName + SYSTEMTYPE + variation + ".txt";
@@ -27,7 +28,7 @@ std::ifstream* GSystemTextFactory::gSystemTextFileStream(GSystem* system, const 
 	log->info(0, "gSystemTextFileStream filename is: ", fname);
 
 	// default dir is "."
-	auto IN = new std::ifstream(fname.c_str());
+	auto IN = std::make_unique<std::ifstream>(fname.c_str());
 
 	if (IN->good()) {
 		log->info(1, "Trying file ", fname);

--- a/gemc/gsystem/gsystemFactories/text/systemTextFactory.h
+++ b/gemc/gsystem/gsystemFactories/text/systemTextFactory.h
@@ -3,6 +3,10 @@
 // gsystem
 #include <gemc/gsystem/gsystemFactories/systemFactory.h>
 
+// c++
+#include <fstream>
+#include <memory>
+
 // file types
 #define GTEXTGEOMTYPE "__geometry_"
 #define GTEXTMATSTYPE "__materials_"
@@ -76,5 +80,5 @@ private:
 	 * - For geometry, failure to locate a file triggers an error unless \c system->getAnnotations() is \c "mats_only".
 	 * - For materials, failure to locate a file is treated as "no materials provided".
 	 */
-	std::ifstream* gSystemTextFileStream(GSystem* system, const std::string& SYSTEMTYPE);
+	std::unique_ptr<std::ifstream> gSystemTextFileStream(GSystem* system, const std::string& SYSTEMTYPE);
 };


### PR DESCRIPTION
`gSystemTextFileStream` returned a heap-allocated `std::ifstream*`; callers only `close()`d it and never `delete`d, leaking one `std::ifstream` per ASCII geometry/material load (and on the not-found / `nullptr` paths). The leak grows with geometry reloads, so long interactive sessions accumulate it.

Return `std::unique_ptr<std::ifstream>` so ownership transfers to the caller and the stream is closed and freed on scope exit. The three `return IN;` sites move the same unique_ptr; `return nullptr;` constructs an empty one. Callers drop the now-redundant `IN->close()` (RAII handles it).

**Validation:** the text factory and both callers compile clean (Geant4 11.4.1 dev container).

Fixes #132