### PR TITLE
Do not crash on "gemc help" with no topic

### DIFF
--- a/gemc/goptions/goptions.cc
+++ b/gemc/goptions/goptions.cc
@@ -100,7 +100,9 @@ GOptions::GOptions(int argc, char* argv[], const GOptions& user_defined_options)
 			exit(EXIT_SUCCESS);
 		}
 		else if (strcmp(argv[i], "help") == 0) {
-			printOptionOrSwitchHelp(argv[i + 1]);
+			// "gemc help <topic>" shows topic help; bare "gemc help" shows the general help index.
+			if (i + 1 < argc) { printOptionOrSwitchHelp(argv[i + 1]); }
+			else { printHelp(); }
 			exit(EXIT_SUCCESS);
 		}
 	}


### PR DESCRIPTION
The early help handler read `argv[i + 1]` without a bounds check. For the bare `gemc help` (the natural way to ask for the help index), `i + 1 == argc`, so `argv[argc]` (the null terminator) was passed to the `std::string` parameter of `printOptionOrSwitchHelp`, throwing `std::logic_error` and aborting. Bounds-check `i + 1 < argc` and fall back to `printHelp()` (which already exists and exits) when no topic follows.

**Validation:** ran in the Geant4 11.4.1 dev container — `gemc help` now prints the help index and exits 0 instead of terminating with an uncaught exception.

Fixes #121