### PR TITLE
Detect YAML inputs by extension and report a missing file cleanly

### DIFF
--- a/gemc/goptions/goptions.cc
+++ b/gemc/goptions/goptions.cc
@@ -284,12 +284,15 @@ void GOptions::printOptionOrSwitchHelp(const std::string& tag) const {
 // Private method: see header. Kept undocumented here to avoid duplicate param docs.
 vector<string> GOptions::findYamls(int argc, char* argv[]) {
 	vector<string> yaml_files;
+	auto ends_with = [](const string& s, const string& suffix) {
+		return s.size() >= suffix.size() &&
+		       s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+	};
 	for (int i = 1; i < argc; i++) {
 		string arg = argv[i];
-		size_t pos = arg.find(".yaml");
-		if (pos != string::npos) yaml_files.push_back(arg);
-		pos = arg.find(".yml");
-		if (pos != string::npos) yaml_files.push_back(arg);
+		// Match a trailing .yaml/.yml extension, not any substring, so option values such as
+		// -prefix=run.yaml.bak are not mistaken for input files (and silently dropped).
+		if (ends_with(arg, ".yaml") || ends_with(arg, ".yml")) yaml_files.push_back(arg);
 	}
 	return yaml_files;
 }
@@ -309,6 +312,11 @@ void GOptions::setOptionsValuesFromYamlFile(const std::string& yaml) {
 	YAML::Node config;
 	try {
 		config = YAML::LoadFile(yaml);
+	}
+	catch (YAML::BadFile& e) {
+		cerr << FATALERRORL << "Cannot open yaml file " << YELLOWHHL << yaml << RSTHHR
+			<< ". Check the path and spelling." << endl;
+		exit(EC__YAML_PARSING_ERROR);
 	}
 	catch (YAML::ParserException& e) {
 		cerr << FATALERRORL << "Error parsing " << YELLOWHHL << yaml << RSTHHR


### PR DESCRIPTION
Two defects in YAML handling:

- `findYamls` classified any token *containing* `.yaml`/`.yml` as an input file (substring match). An option value like `-prefix=run.yaml.bak` was misclassified, then skipped from option parsing and silently dropped, and fed to `YAML::LoadFile`. Match a trailing extension instead.
- `setOptionsValuesFromYamlFile` caught only `YAML::ParserException`. `YAML::LoadFile` throws `YAML::BadFile` (a sibling; both derive from `YAML::Exception`) for a missing/unreadable path, so a mistyped `*.yaml` filename escaped the catch and called `std::terminate`. Add a `BadFile` catch with a clean message.

**Validation:** ran in the Geant4 11.4.1 dev container — `gemc nonexistent.yaml` now prints `Cannot open yaml file ... Check the path and spelling.` and exits cleanly (code 104) instead of terminating with an uncaught exception.

Fixes #125