### PR TITLE
Allow turning a switch off from the CLI (-switch=false)

### DIFF
--- a/gemc/goptions/goptions.cc
+++ b/gemc/goptions/goptions.cc
@@ -129,6 +129,18 @@ GOptions::GOptions(int argc, char* argv[], const GOptions& user_defined_options)
 				string keyPart   = argStr.substr(0, eqPos);
 				string valuePart = argStr.substr(eqPos + 1);
 
+				// Switch with an explicit boolean value: -gui=false / -gui=true. This gives the
+				// CLI a way to turn a switch off, honoring the documented CLI-over-YAML precedence.
+				if (switches.find(keyPart) != switches.end()) {
+					if (valuePart == "true" || valuePart == "1") { switches[keyPart].turnOn(); }
+					else if (valuePart == "false" || valuePart == "0") { switches[keyPart].turnOff(); }
+					else {
+						cerr << "The switch " << keyPart << " accepts only true/false." << endl;
+						exit(EC__NOOPTIONFOUND);
+					}
+					continue;
+				}
+
 				// Strip outer quotes if present (e.g., -gstreamer="[...]")
 				if (!valuePart.empty() && valuePart.front() == '"' && valuePart.back() == '"') {
 					valuePart = valuePart.substr(1, valuePart.length() - 2);


### PR DESCRIPTION
Switches were only recognized in the no-`=` branch, where they are unconditionally turned **on**. Any token with `=` went to the option path, so `-gui=false` was parsed as an option named `gui` — which doesn't exist (it's a switch) — and exited with "The option gui is not known to this system." A switch enabled in a YAML file therefore could not be overridden off on the command line, contradicting the documented CLI-over-YAML precedence.

Intercept `-<switch>=<bool>` before the option branch and route `true`/`1` to `turnOn()` and `false`/`0` to `turnOff()` (both already exist in `GSwitch`); reject other values. The bare `-switch` form still works via the existing branch.

**Validation:** ran in the Geant4 11.4.1 dev container against the b1 example: `-printSystemsMaterials=true` prints 10 materials, `-printSystemsMaterials=false` prints 0 (the off override actually takes effect), and `-printSystemsMaterials=maybe` is rejected with "accepts only true/false".

Fixes #131