### PR TITLE
Correct INSTALL_TARBALL.md: gemc is dynamically linked, not static

### DIFF
--- a/ci/package_install.sh
+++ b/ci/package_install.sh
@@ -251,9 +251,9 @@ This archive contains the GEMC install tree without \`python_env\`. Install pyge
 python3 -m pip install pygemc
 \`\`\`
 
-## Geant4 data
+## Geant4 runtime and data
 
-GEMC is statically linked against Geant4, so the Geant4 shared libraries are not included. Geant4 still loads physics data at runtime. Run:
+GEMC is dynamically linked against Geant4 and CLHEP, so a matching Geant4/CLHEP runtime (the same version this build was compiled against) must be available at runtime. Put its libraries on \`LD_LIBRARY_PATH\` — for example by sourcing the Geant4 \`geant4.sh\` — before running gemc. The Geant4 *data* files are not bundled either; install them with the script below. Then run:
 
 \`\`\`bash
 ./install_geant4_data.sh


### PR DESCRIPTION
The generated `INSTALL_TARBALL.md` claimed "GEMC is statically linked against Geant4," but the packaging step (`ci/package_install.sh`) just `cp -a`s the meson-install tree — no static relink — and that binary dynamically resolves ~30 `libG4*.so` plus `libCLHEP`. A user following the doc (`source gemc.env`, `gemc -v`) hits "cannot open shared object file" because no Geant4/CLHEP runtime is bundled or guaranteed on the host.

Per maintainer direction, this is the docs-only fix (the issue's Option A): make the documentation match the artifact rather than change linking. The text now states gemc is dynamically linked against Geant4 and CLHEP and that a matching runtime must be on `LD_LIBRARY_PATH` (e.g. by sourcing `geant4.sh`) before running, and notes the data files are likewise not bundled. Section header widened to "Geant4 runtime and data".

Docs-only change to the packaging heredoc; no packaging behavior changes.

**Validation:** `bash -n ci/package_install.sh` passes, and rendering the heredoc in isolation produces the intended markdown (escaped backticks stay literal, no command substitution).

Fixes #123