### PR TITLE
Normalize run weights before stochastic event distribution

### DIFF
--- a/gemc/eventDispenser/eventDispenser.cc
+++ b/gemc/eventDispenser/eventDispenser.cc
@@ -104,10 +104,19 @@ void EventDispenser::distributeEvents(int nevents_to_process) {
 	mt19937                     generator(randomDevice());
 	uniform_real_distribution<> randomDistribution(0, 1);
 
+	// Weights in the run-weights file are relative, not required to sum to 1. Compute the total
+	// once and scale each draw by it, so non-normalized weights distribute events correctly.
+	double totalWeight = 0;
+	for (const auto& weight : runWeights) { totalWeight += weight.second; }
+	if (totalWeight <= 0) {
+		log->error(ERR_EVENTDISTRIBUTIONFILENOTFOUND,
+		           "Run weights sum to ", totalWeight, " (must be > 0). Check your run weights file.");
+		return;
+	}
+
 	// For each event, select a run by comparing a random draw to the cumulative weight intervals.
-	// This assumes runWeights values represent fractions or relative weights normalized to sum to 1.
 	for (int i = 0; i < nevents_to_process; i++) {
-		double randomNumber = randomDistribution(generator);
+		double randomNumber = randomDistribution(generator) * totalWeight;
 
 		double cumulativeWeight = 0;
 		for (const auto& weight : runWeights) {


### PR DESCRIPTION
`distributeEvents` drew `randomNumber` from `U[0,1]` and compared it to a running sum of the **raw** file weights. The weights are relative and not required to sum to 1, so for a file like `11 1 / 12 7 / 13 2` (cumulative bins 1/8/10) every draw is `<= 1` and the first run always wins — runs 12 and 13 get zero events, with no warning. The inner comment even stated the unenforced assumption.

Compute the total weight once and scale each draw by it (and guard a non-positive total). Scaling the draw rather than mutating `runWeights` keeps the logged weight table showing the user's original values.

**Validation:** a `1/7/2` weights file over 1000 events now distributes **97/697/206** (~10/70/20%) in the Geant4 11.4.1 dev container; before, all 1000 went to the first run.

Fixes #103