### PR TITLE
Clone the registry GTouchable per step to stop cross-event state leak

### DIFF
--- a/gemc/gsd/gsd.h
+++ b/gemc/gsd/gsd.h
@@ -195,7 +195,9 @@ private:
 		std::string vname = thisStep->GetPreStepPoint()->GetTouchable()->GetVolume()->GetName();
 
 		auto it = gTouchableMap.find(vname);
-		if (it != gTouchableMap.end()) { return it->second; }
+		// Return a per-step copy: ProcessHits and processTouchable mutate trackId, pid and the
+		// time-cell index, so the registry entry must stay pristine across steps and events.
+		if (it != gTouchableMap.end()) { return std::make_shared<GTouchable>(*it->second); }
 		// If not found, log an error. The calling code assumes a valid pointer.
 		log->error(ERR_DYNAMICPLUGINNOTFOUND, "GTouchable for volume " + vname + " not found in gTouchableMap");
 	}


### PR DESCRIPTION
`getGTouchable` returned the persistent `shared_ptr<GTouchable>` stored in `gTouchableMap`, and `ProcessHits`/`processTouchable` mutate it each step (`trackId`, `pid`, `stepTimeAtElectronicsIndex`). `Initialize()` clears the per-event `touchableVector` but never resets those mutations, so at the start of each event the registry object still holds the previous event's time-cell index. `processTouchableImpl` branches on that index, so the first step of a new event can be misrouted (a spurious clone / wrong time cell), and stale `trackId`/`pid` carry over.

Return a per-step **copy** so the registry entry stays pristine. Each step then starts from the clean `UNSET` identity, and within-event grouping still works because the hit collection / `touchableVector` group by `operator==` over field *values* (freshly assigned per step), not by object identity. `gsd.h` documents instances as thread-local with a per-worker map, so the clone introduces no cross-thread sharing.

**Validation:** ran the cherenkov example (gPhotonDetector SD, 20 events, fixed `-seed`) before and after — the hit physics is **byte-identical** (only the wall-clock timestamp column differs), i.e. no regression, while the fix removes the cross-event index carryover that affects readout SDs (Geant4 11.4.1 dev container).

Note: this is the issue's primary (clone) fix. For readout-type SDs it changes behavior by design — it stops the cross-event bleed and the spurious double-cell contribution from `processTouchableImpl`'s clone-on-change branch; each step now routes to exactly one time cell via `operator==`.

Fixes #113