### PR TITLE
Initialize EventDispenser variation from a new -variation option

### DIFF
--- a/gemc/eventDispenser/eventDispenser.cc
+++ b/gemc/eventDispenser/eventDispenser.cc
@@ -29,6 +29,7 @@ EventDispenser::EventDispenser(const std::shared_ptr<GOptions>&                 
 	string filename  = gopt->getScalarString("run_weights");
 	userRunno        = gopt->getScalarInt("run");
 	neventsToProcess = gopt->getScalarInt("n");
+	variation        = gopt->getScalarString("variation");
 
 	// Detect offscreen mode once at construction so processEvents() needs no vis headers.
 	// g4view is only defined when g4display options are included (e.g. in the full gemc app).

--- a/gemc/eventDispenser/eventDispenser_options.cc
+++ b/gemc/eventDispenser/eventDispenser_options.cc
@@ -29,6 +29,12 @@ GOptions defineOptions() {
 	help += "Example: -run=12\n";
 	goptions.defineOption(GVariable("run", 1, "sets run number"), help);
 
+	// Option: digitization variation (constants / translation-table version selector).
+	// Defaults to "default", matching the geometry-side variation default.
+	help = "Variation passed to digitization routines when loading constants and translation tables.\n";
+	help += "Example: -variation=default\n";
+	goptions.defineOption(GVariable("variation", "default", "digitization constants/TT variation"), help);
+
 	// Option: run weights file
 	help = "Text file with run number and their weights.\n \n";
 	help += GTAB;


### PR DESCRIPTION
`EventDispenser::variation` was default-constructed (`""`) and never set, yet it is forwarded to `loadConstants`/`loadTT` for every run. Digitization routines that key calibration/translation data on the variation received an empty string instead of `"default"` (the geometry side already defaults to `"default"`), so run-dependent digitization was effectively un-versioned and disagreed with the geometry.

There was no top-level `variation` option to read (`variation` existed only as a per-system sub-field of `gsystem`), so add one defaulting to `"default"` (matching the geometry default) and read it in the constructor.

**Validation:** `-variation=testvar123` is accepted and the run completes in the Geant4 11.4.1 dev container (previously there was no such option to set).

Fixes #124