### PR TITLE
Free G4World's G4Volume wrappers; forbid copy/move to avoid double-free

### DIFF
--- a/gemc/g4system/g4world.h
+++ b/gemc/g4system/g4world.h
@@ -63,6 +63,19 @@ public:
 	 */
 	G4World(const GWorld* gworld, const std::shared_ptr<GOptions>& gopts);
 
+	/// Frees the owned G4Volume wrappers. Geant4 owns the contained solid/logical/physical
+	/// objects, so only the lightweight wrappers allocated by the object factories are deleted.
+	~G4World() {
+		for (auto& [name, vol] : g4volumesMap) { delete vol; }
+	}
+
+	// G4World now owns the raw G4Volume* wrappers (freed in the destructor). It is only ever held
+	// by shared_ptr, so forbid copy/move to avoid a shallow copy double-freeing the wrappers.
+	G4World(const G4World&)            = delete;
+	G4World& operator=(const G4World&) = delete;
+	G4World(G4World&&)                 = delete;
+	G4World& operator=(G4World&&)      = delete;
+
 	// ────── lookup / mutators ────────────────────────────────────────
 
 	/**


### PR DESCRIPTION
`G4World` stored raw `G4Volume*` wrappers in `g4volumesMap` but had no destructor, so every `g4world.reset()` on geometry reload leaked one wrapper per volume — unbounded growth in long interactive sessions (large SoLID-scale geometries reloaded many times).

Add a destructor that deletes the wrappers — Geant4 owns the contained solid/logical/physical objects, so only the lightweight GEMC wrappers are freed. Because `G4World` previously inherited GBase's *defaulted* copy/move, adding an owning destructor would make a shallow copy double-free; `G4World` is only ever held by `shared_ptr`, so this also deletes copy and move to forbid relocation (closing the same class of bug as #136).

**Validation:** rebuilt `gemc` in the Geant4 11.4.1 dev container — the deleted copy/move compile cleanly, confirming nothing copies or moves `G4World`.

Fixes #135