### PR TITLE
Add rule-of-five to GFrameDataCollection to prevent double-free

### DIFF
--- a/gemc/gdata/frame/gFrameDataCollection.h
+++ b/gemc/gdata/frame/gFrameDataCollection.h
@@ -67,6 +67,13 @@ public:
 		integralPayloads = new std::vector<GIntegralPayload*>();
 	}
 
+	// Owns raw pointers freed in the destructor: forbid copy (a shallow copy would double-free)
+	// and move (no current need; re-enable with explicit pointer-nulling move ops if required).
+	GFrameDataCollection(const GFrameDataCollection&)            = delete;
+	GFrameDataCollection& operator=(const GFrameDataCollection&) = delete;
+	GFrameDataCollection(GFrameDataCollection&&)                 = delete;
+	GFrameDataCollection& operator=(GFrameDataCollection&&)      = delete;
+
 	/**
 	 * \brief Destructor.
 	 *


### PR DESCRIPTION
`GFrameDataCollection` owns three raw pointers (`gevent_header`, the payload objects, and the heap-allocated payload vector) and deletes them in its destructor, but declared no copy/move operations. The implicitly generated copy/move do a **shallow** pointer copy, so any copy (stored by value, passed by value, returned pre-elision) would give two owners and double-free on destruction.

No active copy site exists today, so this is a latent footgun. Delete copy and move to make the ownership intent explicit and close the hole; the documented long-term fix is `unique_ptr` members.

**Validation:** rebuilt `gemc` in the Geant4 11.4.1 dev container — the deletions compile cleanly, confirming nothing currently copies or moves it.

Fixes #136